### PR TITLE
Add Craig Duhn (cduhn17) to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 # These owners will be the default owners for everything in the
 # repo. Unless a later match takes precedence, these owners will be
 # requested for review when someone opens a pull request.
-* @aloftus23 @dav3r @DJensen94 @elr64 @felddy @jsf9k @mcdonnnj @schmelz-ctr @stewartl97
+* @aloftus23 @cduhn17 @dav3r @DJensen94 @elr64 @felddy @jsf9k @mcdonnnj @schmelz-ctr @stewartl97
 
 # These folks own any files in the .github directory at the root of
 # the repository and any of its subdirectories.


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds @cduhn17 to the codeowners for this repository.

## 💭 Motivation and context ##

@cduhn is a new member of the P&E team.

## 🧪 Testing ##

All `pre-commit` hooks and GitHub Actions pass.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
