### PR TITLE
Add dark web schema to sql

### DIFF
--- a/src/pe_reports/data/data_schema.sql
+++ b/src/pe_reports/data/data_schema.sql
@@ -6,17 +6,17 @@
 -- Includes Domain Masquerading, Credentals Exposed, Inffered Vulns, and Dark Web data
 
 BEGIN;
-
--- Organizations table
-CREATE TABLE IF NOT EXISTS public.organizations
+-- Organization Assets
+-- Alias Table
+CREATE TABLE IF NOT EXISTS public.alias
 (
+    alias_id text NOT NULL,
     organization_id text NOT NULL,
-    name text NOT NULL,
-    root_domains text[],
-    PRIMARY KEY (organization_id)
+    alias text NOT NULL,
+    PRIMARY KEY (alias_id)
 );
 
--- Domains table
+-- Domains Table
 CREATE TABLE IF NOT EXISTS public.domains
 (
     domain_id text NOT NULL,
@@ -26,23 +26,42 @@ CREATE TABLE IF NOT EXISTS public.domains
     PRIMARY KEY (domain_id)
 );
 
--- Alias table
-CREATE TABLE IF NOT EXISTS public.alias
+-- Executives Table
+CREATE TABLE IF NOT EXISTS public.executives
 (
-    alias_id text NOT NULL,
+    executives_id text NOT NULL,
     organization_id text NOT NULL,
-    alias text NOT NULL,
-    PRIMARY KEY (alias_id)
+    executives text NOT NULL,
+    PRIMARY KEY (executives_id)
 );
 
--- Aliases table : Postgres
-CREATE TABLE IF NOT EXISTS public.alias
+-- Organizations Table
+CREATE TABLE IF NOT EXISTS public.organizations
 (
-    alias_id serial NOT NULL PRIMARY KEY,
     organization_id text NOT NULL,
-    alias text NOT NULL,
+    name text NOT NULL,
+    PRIMARY KEY (organization_id)
 );
 
+-- Report Data
+-- Dark Web Alerts Table
+CREATE TABLE IF NOT EXISTS public.alerts
+(
+    id text NOT NULL,
+    alert_name text,
+    content text,
+    date text,
+    sixgill_id text,
+    read text,
+    severity text,
+    site text,
+    threat_level text,
+    threats text,
+    title text,
+    user_id text,
+    organization_id text NOT NULL,
+    PRIMARY KEY (id)
+);
 
 -- Domain Masquerading Table
 CREATE TABLE IF NOT EXISTS public."DNSTwist"
@@ -61,6 +80,62 @@ CREATE TABLE IF NOT EXISTS public."DNSTwist"
     PRIMARY KEY (id)
 );
 
+-- Dark Web Forumns Table
+CREATE TABLE IF NOT EXISTS public.forumns
+(
+    id text NOT NULL,
+    friendly_name text,
+    description text,
+    site text NOT NULL,
+    PRIMARY KEY (id)
+);
+
+-- Dark Web Mentions Table
+CREATE TABLE IF NOT EXISTS public.mentions
+(
+    id text NOT NULL,
+    category text,
+    collection_date text,
+    content text,
+    creator text,
+    date text,
+    post_id text,
+    rep_grade text,
+    site text,
+    site_grade text,
+    title text,
+    type text,
+    url text,
+    tags text,
+    comments_count text,
+    sub_category text,
+    query text,
+    organization_id text NOT NULL,
+    PRIMARY KEY (id)
+);
+
+-- Dark Web Threats Table
+CREATE TABLE IF NOT EXISTS public.dw_threats
+(
+    id text NOT NULL,
+    threat text,
+    description text,
+    organization_id text NOT NULL,
+    PRIMARY KEY (id)
+);
+
+-- Top CVEs Table
+CREATE TABLE IF NOT EXISTS public.top_cves
+(
+    id text NOT NULL,
+    type text,
+    cve text,
+    description text,
+    PRIMARY KEY (id)
+);
+
+
+-- Database Relationships
 -- One to many relation between Organization and Domains
 ALTER TABLE public.organizations
     ADD FOREIGN KEY (organization_id)
@@ -77,6 +152,42 @@ ALTER TABLE public.organizations
 ALTER TABLE public.domains
     ADD FOREIGN KEY (domain_id)
     REFERENCES public."DNSTwist" ("discoveredBy")
+    NOT VALID;
+
+-- One to many relation between Organization and Aliases
+ALTER TABLE public.organizations
+    ADD FOREIGN KEY (executives_id)
+    REFERENCES public.executives (organization_id)
+    NOT VALID;
+
+-- One to many relation between Organization and Aliases
+ALTER TABLE public.organization
+    ADD FOREIGN KEY (organization_id)
+    REFERENCES public.alias (organization_id)
+    NOT VALID;
+
+-- One to many relation between Mention "sites" and Forumns
+ALTER TABLE public.mentions
+    ADD FOREIGN KEY (site)
+    REFERENCES public.forums (site)
+    NOT VALID;
+
+-- One to many relation between Mention "aliases" and Alias
+ALTER TABLE public.alias
+    ADD FOREIGN KEY (aliases)
+    REFERENCES public.mentions (query)
+    NOT VALID;
+
+-- One to many relation between Organization and Alerts
+ALTER TABLE public.organization
+    ADD FOREIGN KEY (organization_id)
+    REFERENCES public.alerts (organization_id)
+    NOT VALID;
+
+-- One to many relation between Alerts "threats" and Alerts
+ALTER TABLE public.alerts
+    ADD FOREIGN KEY (threats)
+    REFERENCES public.threats (threat)
     NOT VALID;
 
 END;

--- a/src/pe_reports/data/data_schema.sql
+++ b/src/pe_reports/data/data_schema.sql
@@ -189,4 +189,36 @@ ALTER TABLE public.hibp_exposed_credentials
     REFERENCES public.hibp_breaches (breach_name)
     NOT VALID;
 
+-- HIBP complete breach view
+Create View vw_breach_complete
+AS
+SELECT creds.credential_id,creds.email, creds.breach_name, creds.root_domain, creds.sub_domain,
+    b.description, b.breach_date, b.added_date, b.modified_date,  b.data_classes,
+    b.password_included, b.is_verified, b.is_fabricated, b.is_sensitive, b.is_retired, b.is_spam_list
+
+    FROM hibp_exposed_credentials as creds
+
+    JOIN hibp_breaches as b
+    ON creds.breach_name = b.breach_name;
+
+
+-- Cyber Six Gill exposed credentials table
+CREATE TABLE IF NOT EXISTS public.cybersix_exposed_credentials
+(
+    credential_id serial,
+    breach_date date,
+    "breach_id " integer,
+    breach_name text NOT NULL,
+    create_time timestamp without time zone[],
+    description text,
+    domain text,
+    email text NOT NULL,
+    password text,
+    hash_type text,
+    login_id text,
+    name text,
+    phone text,
+    PRIMARY KEY (credential_id)
+);
+
 END;

--- a/src/pe_reports/data/data_schema.sql
+++ b/src/pe_reports/data/data_schema.sql
@@ -209,11 +209,11 @@ ALTER TABLE public.organizations
     REFERENCES public.alerts (organization_id)
     NOT VALID;
 
--- One to Many Relationship for Mentions 
--- Represented in complex SixGill "query: API.
+-- One to Many Relationship for Mentions
+-- Represented in complex SixGill "query": API.
 
 
--- Views -- 
+-- Views --
 -- HIBP complete breach view
 Create View vw_breach_complete
 AS

--- a/src/pe_reports/data/data_schema.sql
+++ b/src/pe_reports/data/data_schema.sql
@@ -26,6 +26,24 @@ CREATE TABLE IF NOT EXISTS public.domains
     PRIMARY KEY (domain_id)
 );
 
+-- Alias table
+CREATE TABLE IF NOT EXISTS public.alias
+(
+    alias_id text NOT NULL,
+    organization_id text NOT NULL,
+    alias text NOT NULL,
+    PRIMARY KEY (alias_id)
+);
+
+-- Aliases table : Postgres
+CREATE TABLE IF NOT EXISTS public.alias
+(
+    alias_id serial NOT NULL PRIMARY KEY,
+    organization_id text NOT NULL,
+    alias text NOT NULL,
+);
+
+
 -- Domain Masquerading Table
 CREATE TABLE IF NOT EXISTS public."DNSTwist"
 (


### PR DESCRIPTION
## 🗣 Description ##

To run dark web scans, tables addressing particular organizational assets and dark web output are required. At a minimum, tables for the organization includes; `alias`, `domains`, `ip_addresses`, `executives`. For the collection of output the following tables are required; `mentions`, `alerts`, `forums`, `threats`,` top_cves`. If a corresponding table already exist at merge, the preexisting table will be used. 

## 💭 Motivation and context ##
Adding the minimum required tables to` data/data_schema.sql `will support dark web scans. This effort also leads to the ability for multiple users to build out a database for P&E Reports 1.0.0.

Out of Scope but available tables include:
- organization: bins, cves, host_names, mac_addresses, network_names, products, third_parties
- output: dve

## 🧪 Testing ##

To test: data/data_schema.sql runs successfully and builds out schema. The environment is a local Postgres database. No other `pe-reports` code should be altered


## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
