### PR TITLE
Add credential exposure tables and adjust foreign keys

### DIFF
--- a/src/pe_reports/data/data_schema.sql
+++ b/src/pe_reports/data/data_schema.sql
@@ -44,21 +44,89 @@ CREATE TABLE IF NOT EXISTS public."DNSTwist"
 );
 
 -- One to many relation between Organization and Domains
-ALTER TABLE public.organizations
-    ADD FOREIGN KEY (organization_id)
-    REFERENCES public.domains (organization_id)
-    NOT VALID;
+ALTER TABLE public.domains
+ ADD FOREIGN KEY (organization_id)
+ REFERENCES public.organizations (organization_id)
+ NOT VALID;
 
 -- One to many relation between Organization and DNSTwist results
-ALTER TABLE public.organizations
-    ADD FOREIGN KEY (organization_id)
-    REFERENCES public."DNSTwist" (organization_id)
-    NOT VALID;
+ALTER TABLE public."DNSTwist"
+ ADD FOREIGN KEY (organization_id)
+ REFERENCES public.organizations (organization_id)
+ NOT VALID;
 
 -- One to many relation between Domains and DNSTwist results
-ALTER TABLE public.domains
-    ADD FOREIGN KEY (domain_id)
-    REFERENCES public."DNSTwist" ("discoveredBy")
+ALTER TABLE public."DNSTwist"
+ ADD FOREIGN KEY ("discoveredBy")
+ REFERENCES public.domains ("domain_id")
+ NOT VALID;
+
+-- HIBP breaches table
+CREATE TABLE IF NOT EXISTS public.hibp_breaches
+(
+    breach_name text NOT NULL,
+    description text,
+    breach_date date,
+    added_date timestamp without time zone,
+    modified_date timestamp without time zone,
+    data_classes text[],
+    password_included boolean,
+    is_verified boolean,
+    is_fabricated boolean,
+    is_sensitive boolean,
+    is_retired boolean,
+    is_spam_list boolean,
+    PRIMARY KEY (breach_name)
+);
+
+-- HIBP exposed credentials table
+CREATE TABLE IF NOT EXISTS public.hibp_exposed_credentials
+(
+    credential_id serial,
+    email text NOT NULL,
+    root_domain text,
+    sub_domain text,
+    breach_name text,
+    UNIQUE (email, breach_name),
+    PRIMARY KEY (credential_id)
+);
+
+ALTER TABLE public.hibp_exposed_credentials
+    ADD FOREIGN KEY (breach_name)
+    REFERENCES public.hibp_breaches (breach_name)
     NOT VALID;
+
+-- HIBP complete breach view
+Create View vw_breach_complete
+AS
+SELECT creds.credential_id,creds.email, creds.breach_name, creds.root_domain, creds.sub_domain,
+    b.description, b.breach_date, b.added_date, b.modified_date,  b.data_classes,
+    b.password_included, b.is_verified, b.is_fabricated, b.is_sensitive, b.is_retired, b.is_spam_list
+
+    FROM hibp_exposed_credentials as creds
+
+    JOIN hibp_breaches as b
+    ON creds.breach_name = b.breach_name;
+
+
+-- Cyber Six Gill exposed credentials table
+CREATE TABLE IF NOT EXISTS public.cybersix_exposed_credentials
+(
+    credential_id serial,
+    breach_date date,
+    "breach_id " integer,
+    breach_name text NOT NULL,
+    create_time timestamp without time zone[],
+    description text,
+    domain text,
+    email text NOT NULL,
+    password text,
+    hash_type text,
+    login_id text,
+    name text,
+    phone text,
+    PRIMARY KEY (credential_id)
+);
+
 
 END;


### PR DESCRIPTION
Added data models for the postgres database for the different hibp and cybersix exposure sources. Also updated direction of the relationships in dns tables to point the correct direction
fixes #38 

## 💭 Motivation and context ##
• This change is required to get the initial database configuration set up to model the data we are pulling from our various APIs that we will then use when generating our reports.
• This solves our problem of not having a model/ or location to store the data we need for our report

## 🧪 Testing ##
passes pre-commits and pytest

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
