### PR TITLE
add organization to the data schema for hibp

### DIFF
--- a/src/pe_reports/data/data_schema.sql
+++ b/src/pe_reports/data/data_schema.sql
@@ -129,6 +129,7 @@ CREATE TABLE IF NOT EXISTS public.hibp_exposed_credentials
 (
     credential_id serial,
     email text NOT NULL,
+    organization text,
     root_domain text,
     sub_domain text,
     breach_name text,
@@ -217,7 +218,7 @@ ALTER TABLE public.organizations
 -- HIBP complete breach view
 Create View vw_breach_complete
 AS
-SELECT creds.credential_id,creds.email, creds.breach_name, creds.root_domain, creds.sub_domain,
+SELECT creds.credential_id,creds.email, creds.breach_name, creds.organization, creds.root_domain, creds.sub_domain,
     b.description, b.breach_date, b.added_date, b.modified_date,  b.data_classes,
     b.password_included, b.is_verified, b.is_fabricated, b.is_sensitive, b.is_retired, b.is_spam_list
 


### PR DESCRIPTION
Added the organization to the data schema to facilitate querying for report generation

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
This PR only adds one field to the hibp_exposed_credentials table and the hibp view

## 💭 Motivation and context ##
Previously there was no way to easily query all credential breaches for a specific organization. adding this field to the table and view will allow us to pull all values for a specific organization in a specified time frame.

## 🧪 Testing ##

Should pass with the same tests as before

## ✅ Checklist ##
- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
