### PR TITLE
Fix syntax/naming errors in PE data schema 

### DIFF
--- a/src/pe_reports/data/data_schema.sql
+++ b/src/pe_reports/data/data_schema.sql
@@ -134,6 +134,7 @@ CREATE TABLE IF NOT EXISTS public.shodan_insecure_protocols_unverified_vulns
     UNIQUE (organizations_uid, ip, port, protocol, timestamp),
     PRIMARY KEY (insecure_product_uid)
 );
+
 --Shodan Veriried Vulnerabilities table
 CREATE TABLE IF NOT EXISTS public.shodan_verified_vulns
 (
@@ -167,6 +168,7 @@ CREATE TABLE IF NOT EXISTS public.shodan_verified_vulns
     UNIQUE (organizations_uid, ip, port, protocol, timestamp),
     PRIMARY KEY (verified_vuln_uid)
 );
+
 --Shodan Assets and IPs table
 CREATE TABLE IF NOT EXISTS public.shodan_assets
 (
@@ -253,6 +255,7 @@ CREATE TABLE IF NOT EXISTS public.top_cves
     PRIMARY KEY (top_cves_uid)
 );
 
+
 -- Table Relationships --
 -- One to many relation between Organization and Domains
 ALTER TABLE public.domains
@@ -326,8 +329,10 @@ ALTER TABLE public.alerts
     REFERENCES public.organizations (organizations_uid)
     NOT VALID;
 
+
 -- One to Many Relationship for Mentions
 -- Represented in complex SixGill "query": API.
+
 
 -- Views --
 -- HIBP complete breach view

--- a/src/pe_reports/data/data_schema.sql
+++ b/src/pe_reports/data/data_schema.sql
@@ -114,7 +114,7 @@ CREATE TABLE IF NOT EXISTS public.mentions
 CREATE TABLE IF NOT EXISTS public.shodan_insecure_protocols_unverified_vulns
 (
     insecure_product_uid uuid default uuid_generate_v1() NOT NULL,
-    organization_uid uuid NOT NULL,
+    organizations_uid uuid NOT NULL,
     organization text,
     ip text,
     port integer,
@@ -131,14 +131,14 @@ CREATE TABLE IF NOT EXISTS public.shodan_insecure_protocols_unverified_vulns
     hostnames text[],
     isn text,
     asn integer,
-    UNIQUE (root_org, ip, port, protocol, timestamp),
+    UNIQUE (organizations_uid, ip, port, protocol, timestamp),
     PRIMARY KEY (insecure_product_uid)
 );
 --Shodan Veriried Vulnerabilities table
 CREATE TABLE IF NOT EXISTS public.shodan_verified_vulns
 (
     verified_vuln_uid uuid default uuid_generate_v1() NOT NULL,
-    organization_uid uuid NOT NULL,
+    organizations_uid uuid NOT NULL,
     organization text,
     ip text,
     port text,
@@ -164,14 +164,14 @@ CREATE TABLE IF NOT EXISTS public.shodan_verified_vulns
     hostnames text[],
     isn text,
     asn integer,
-    UNIQUE (root_org, ip, port, protocol, timestamp),
+    UNIQUE (organizations_uid, ip, port, protocol, timestamp),
     PRIMARY KEY (verified_vuln_uid)
 );
 --Shodan Assets and IPs table
 CREATE TABLE IF NOT EXISTS public.shodan_assets
 (
     shodan_asset_uid uuid default uuid_generate_v1() NOT NULL,
-    organization_uid uuid NOT NULL,
+    organizations_uid uuid NOT NULL,
     organization text,
     ip text,
     port integer,
@@ -184,7 +184,7 @@ CREATE TABLE IF NOT EXISTS public.shodan_assets
     hostnames text[],
     isn text,
     asn integer,
-    UNIQUE (root_org, ip, port, protocol, timestamp),
+    UNIQUE (organizations_uid, ip, port, protocol, timestamp),
     PRIMARY KEY (shodan_asset_uid)
 );
 
@@ -193,7 +193,7 @@ CREATE TABLE IF NOT EXISTS public.hibp_breaches
 (
     hibp_breaches_uid uuid default uuid_generate_v1() NOT NULL,
     breach_id uuid NOT NULL,
-    breach_name text NOT NULL
+    breach_name text NOT NULL,
     description text,
     exposed_cred_count bigint,
     breach_date date,
@@ -333,7 +333,7 @@ ALTER TABLE public.alerts
 -- HIBP complete breach view
 Create View vw_breach_complete
 AS
-SELECT creds.hibp_exposed_credentials_uid,creds.email, creds.breach_name, creds.organization, creds.root_domain, creds.sub_domain,
+SELECT creds.hibp_exposed_credentials_uid,creds.email, creds.breach_name, creds.organizations_uid, creds.root_domain, creds.sub_domain,
     b.description, b.breach_date, b.added_date, b.modified_date,  b.data_classes,
     b.password_included, b.is_verified, b.is_fabricated, b.is_sensitive, b.is_retired, b.is_spam_list
 


### PR DESCRIPTION
## 🗣 Description ##

During database setup, we encountered a couple syntax and naming errors that needed to be adjusted.

## 💭 Motivation and context ##

Changes were required to set up the PE database instance in Crossfeed.


## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All existing tests pass.
