### PR TITLE
Uploads P&E reports to S3 bucket when generated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .DS_Store
 
 ## Project Specific ##
+build/*
 output/
 
 ## Python ##

--- a/src/pe_reports/report_generator.py
+++ b/src/pe_reports/report_generator.py
@@ -46,7 +46,7 @@ def upload_file_to_s3(file_name, datestring, bucket):
 
     try:
         response = s3_client.upload_file(file_name, bucket, object_name)
-        if response == None:
+        if response is None:
             LOGGER.info("Success uploading to S3.")
         else:
             LOGGER.info(response)

--- a/tests/test_pe_reports.py
+++ b/tests/test_pe_reports.py
@@ -2,6 +2,7 @@
 
 # Standard Python Libraries
 import logging
+import os
 import sys
 from unittest.mock import patch
 
@@ -152,12 +153,12 @@ def test_stakeholder_page(client):
     assert resp.status_code == 200
     assert b"Stakeholder" in resp.data
 
-
+@patch.object(pe_reports.report_generator, "upload_file_to_s3")
 @patch.object(pe_reports.report_generator, "embed")
 @patch.object(pe_reports.report_generator, "init")
 @patch.object(pe_reports.report_generator, "get_orgs")
 @patch.object(pe_reports.report_generator, "connect")
-def test_report_generator(mock_db_connect, mock_get_orgs, mock_init, mock_embed):
+def test_report_generator(mock_db_connect, mock_get_orgs, mock_init, mock_embed, mock_s3_upload):
     """Test report is generated."""
     mock_db_connect.return_value = "connection"
     mock_get_orgs.return_value = [("pe_org_uid", "Test Org", "TestOrg")]
@@ -182,8 +183,10 @@ def test_report_generator(mock_db_connect, mock_get_orgs, mock_init, mock_embed)
         alerts,
         top_cves,
     )
-    mock_embed.return_value = 10000000, False
+    mock_embed.return_value = 10000000, False, "output/TestOrg/Posture_and_Exposure_Report-TestOrg-2022-09-30.pdf"
+    
     return_value = pe_reports.report_generator.generate_reports("2022-09-30", "output")
+    mock_s3_upload.assert_called_once_with("output/TestOrg/Posture_and_Exposure_Report-TestOrg-2022-09-30.pdf", "2022-09-30", None)
     assert return_value == 1
 
 

--- a/tests/test_pe_reports.py
+++ b/tests/test_pe_reports.py
@@ -2,7 +2,6 @@
 
 # Standard Python Libraries
 import logging
-import os
 import sys
 from unittest.mock import patch
 
@@ -153,12 +152,15 @@ def test_stakeholder_page(client):
     assert resp.status_code == 200
     assert b"Stakeholder" in resp.data
 
+
 @patch.object(pe_reports.report_generator, "upload_file_to_s3")
 @patch.object(pe_reports.report_generator, "embed")
 @patch.object(pe_reports.report_generator, "init")
 @patch.object(pe_reports.report_generator, "get_orgs")
 @patch.object(pe_reports.report_generator, "connect")
-def test_report_generator(mock_db_connect, mock_get_orgs, mock_init, mock_embed, mock_s3_upload):
+def test_report_generator(
+    mock_db_connect, mock_get_orgs, mock_init, mock_embed, mock_s3_upload
+):
     """Test report is generated."""
     mock_db_connect.return_value = "connection"
     mock_get_orgs.return_value = [("pe_org_uid", "Test Org", "TestOrg")]
@@ -183,10 +185,18 @@ def test_report_generator(mock_db_connect, mock_get_orgs, mock_init, mock_embed,
         alerts,
         top_cves,
     )
-    mock_embed.return_value = 10000000, False, "output/TestOrg/Posture_and_Exposure_Report-TestOrg-2022-09-30.pdf"
-    
+    mock_embed.return_value = (
+        10000000,
+        False,
+        "output/TestOrg/Posture_and_Exposure_Report-TestOrg-2022-09-30.pdf",
+    )
+
     return_value = pe_reports.report_generator.generate_reports("2022-09-30", "output")
-    mock_s3_upload.assert_called_once_with("output/TestOrg/Posture_and_Exposure_Report-TestOrg-2022-09-30.pdf", "2022-09-30", None)
+    mock_s3_upload.assert_called_once_with(
+        "output/TestOrg/Posture_and_Exposure_Report-TestOrg-2022-09-30.pdf",
+        "2022-09-30",
+        None,
+    )
     assert return_value == 1
 
 


### PR DESCRIPTION
fixes #260 

## 🗣 Description ##

Uploads reports to a S3 bucket after they are generated.

## 💭 Motivation and context ##

Improves automation for P&E report storage and retrieval.

## 🧪 Testing ##

Updated pytests and passes all pre-commits.


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
