### PR TITLE
Rename duplicate modules

### DIFF
--- a/src/pe_source/pe_scripts.py
+++ b/src/pe_source/pe_scripts.py
@@ -42,7 +42,7 @@ from .cybersixgill import Cybersixgill
 from .dnsmonitor import DNSMonitor
 from .dnstwistscript import run_dnstwist
 from .intelx_identity import IntelX
-from .shodan import Shodan
+from .pe_shodan import Shodan
 
 LOGGER = logging.getLogger(__name__)
 

--- a/src/pe_source/pe_shodan.py
+++ b/src/pe_source/pe_shodan.py
@@ -7,13 +7,12 @@ import threading
 import numpy
 
 from .data.pe_db.config import shodan_api_init
-from .data.pe_db.db_query import get_orgs
+from .data.pe_db.db_query_source import get_orgs
 from .data.shodan.shodan_search import run_shodan_thread
-
 
 class Shodan:
     """Fetch Shodan data."""
-
+    
     def __init__(self, orgs_list):
         """Initialize Shodan class."""
         self.orgs_list = orgs_list
@@ -24,7 +23,7 @@ class Shodan:
 
         # Get orgs from PE database
         pe_orgs = get_orgs()
-
+        
         # Filter orgs if specified
         if orgs_list == "all":
             pe_orgs_final = pe_orgs
@@ -38,10 +37,13 @@ class Shodan:
 
         # Get list of initialized API objects
         api_list = shodan_api_init()
+        chunked_orgs_list = numpy.array([])
 
-        # Split orgs into chunks. # of chunks = # of valid API keys = # of threads
-        chunk_size = len(api_list)
-        chunked_orgs_list = numpy.array_split(numpy.array(pe_orgs_final), chunk_size)
+        # Split orgs into chunks. # of chunks = # of valid API keys = # of threads 
+        # if list has any valid apis
+        if len(api_list) > 0:
+            chunk_size = len(api_list)
+            chunked_orgs_list = numpy.array_split(numpy.array(pe_orgs_final), chunk_size)
 
         i = 0
         thread_list = []


### PR DESCRIPTION
fixes #578
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Renaming shodan.py to pe_shodan.py and editing the affected module imports.
Also added a check for fields in API list in pe_shodan.py to eliminate failure upon empty list.