### PR TITLE
Renaming duplicate modules

### DIFF
--- a/src/pe_source/pe_scripts.py
+++ b/src/pe_source/pe_scripts.py
@@ -22,7 +22,6 @@ Options:
                                     If not specified, all will run. Valid values are "alerts",
                                     "credentials", "mentions", "topCVEs". E.g. alerts,mentions.
                                     [default: all]
-  -sc --soc_med_included            Include social media posts from cybersixgill in data collection.
 """
 
 # Standard Python Libraries
@@ -39,7 +38,6 @@ import pe_reports
 
 from ._version import __version__
 from .cybersixgill import Cybersixgill
-from .dnsmonitor import DNSMonitor
 from .dnstwistscript import run_dnstwist
 from .intelx_identity import IntelX
 from .pe_shodan import Shodan
@@ -47,7 +45,7 @@ from .pe_shodan import Shodan
 LOGGER = logging.getLogger(__name__)
 
 
-def run_pe_script(source, orgs_list, cybersix_methods, soc_med_included):
+def run_pe_script(source, orgs_list, cybersix_methods):
     """Collect data from the source specified."""
     # If not "all", separate orgs string into a list of orgs
     if orgs_list != "all":
@@ -61,14 +59,11 @@ def run_pe_script(source, orgs_list, cybersix_methods, soc_med_included):
     LOGGER.info("Running %s on these orgs: %s", source, orgs_list)
 
     if source == "cybersixgill":
-        cybersix = Cybersixgill(orgs_list, cybersix_methods, soc_med_included)
+        cybersix = Cybersixgill(orgs_list, cybersix_methods)
         cybersix.run_cybersixgill()
     elif source == "shodan":
         shodan = Shodan(orgs_list)
         shodan.run_shodan()
-    elif source == "dnsmonitor":
-        dnsMonitor = DNSMonitor(orgs_list)
-        dnsMonitor.run_dnsMonitor()
     elif source == "dnstwist":
         run_dnstwist(orgs_list)
     elif source == "intelx":
@@ -122,7 +117,6 @@ def main():
         validated_args["DATA_SOURCE"],
         validated_args["--orgs"],
         validated_args["--cybersix-methods"],
-        validated_args["--soc_med_included"],
     )
 
     # Stop logging and clean up

--- a/src/pe_source/pe_scripts.py
+++ b/src/pe_source/pe_scripts.py
@@ -22,6 +22,7 @@ Options:
                                     If not specified, all will run. Valid values are "alerts",
                                     "credentials", "mentions", "topCVEs". E.g. alerts,mentions.
                                     [default: all]
+  -sc --soc_med_included            Include social media posts from cybersixgill in data collection.
 """
 
 # Standard Python Libraries
@@ -38,14 +39,15 @@ import pe_reports
 
 from ._version import __version__
 from .cybersixgill import Cybersixgill
+from .dnsmonitor import DNSMonitor
 from .dnstwistscript import run_dnstwist
 from .intelx_identity import IntelX
-from .shodan import Shodan
+from .pe_shodan import Shodan
 
 LOGGER = logging.getLogger(__name__)
 
 
-def run_pe_script(source, orgs_list, cybersix_methods):
+def run_pe_script(source, orgs_list, cybersix_methods, soc_med_included):
     """Collect data from the source specified."""
     # If not "all", separate orgs string into a list of orgs
     if orgs_list != "all":
@@ -59,11 +61,14 @@ def run_pe_script(source, orgs_list, cybersix_methods):
     LOGGER.info("Running %s on these orgs: %s", source, orgs_list)
 
     if source == "cybersixgill":
-        cybersix = Cybersixgill(orgs_list, cybersix_methods)
+        cybersix = Cybersixgill(orgs_list, cybersix_methods, soc_med_included)
         cybersix.run_cybersixgill()
     elif source == "shodan":
         shodan = Shodan(orgs_list)
         shodan.run_shodan()
+    elif source == "dnsmonitor":
+        dnsMonitor = DNSMonitor(orgs_list)
+        dnsMonitor.run_dnsMonitor()
     elif source == "dnstwist":
         run_dnstwist(orgs_list)
     elif source == "intelx":
@@ -117,6 +122,7 @@ def main():
         validated_args["DATA_SOURCE"],
         validated_args["--orgs"],
         validated_args["--cybersix-methods"],
+        validated_args["--soc_med_included"],
     )
 
     # Stop logging and clean up

--- a/src/pe_source/pe_shodan.py
+++ b/src/pe_source/pe_shodan.py
@@ -24,7 +24,7 @@ class Shodan:
 
         # Get orgs from PE database
         pe_orgs = get_orgs()
-        
+
         # Filter orgs if specified
         if orgs_list == "all":
             pe_orgs_final = pe_orgs

--- a/src/pe_source/pe_shodan.py
+++ b/src/pe_source/pe_shodan.py
@@ -24,7 +24,7 @@ class Shodan:
 
         # Get orgs from PE database
         pe_orgs = get_orgs()
-
+        
         # Filter orgs if specified
         if orgs_list == "all":
             pe_orgs_final = pe_orgs
@@ -38,10 +38,13 @@ class Shodan:
 
         # Get list of initialized API objects
         api_list = shodan_api_init()
+        chunked_orgs_list = numpy.array([])
 
-        # Split orgs into chunks. # of chunks = # of valid API keys = # of threads
-        chunk_size = len(api_list)
-        chunked_orgs_list = numpy.array_split(numpy.array(pe_orgs_final), chunk_size)
+        # Split orgs into chunks. # of chunks = # of valid API keys = # of threads 
+        # if list has any valid apis
+        if len(api_list) > 0:
+            chunk_size = len(api_list)
+            chunked_orgs_list = numpy.array_split(numpy.array(pe_orgs_final), chunk_size)
 
         i = 0
         thread_list = []

--- a/tests/test_pe_source.py
+++ b/tests/test_pe_source.py
@@ -15,7 +15,7 @@ import pe_source.cybersixgill
 import pe_source.data.sixgill.api
 import pe_source.dnstwistscript
 import pe_source.pe_scripts
-import pe_source.shodan
+import pe_source.pe_shodan
 
 log_levels = (
     "debug",


### PR DESCRIPTION
Fixes #581 

## 🗣 Description ##
Renaming shodan.py to pe_shodan.py and editing the affected module imports.
Also added a check for fields in API list in pe_shodan.py to eliminate failure upon empty list.
