### PR TITLE
Replace Get_orgs

### DIFF
--- a/src/pe_reports/data/database.ini
+++ b/src/pe_reports/data/database.ini
@@ -1,12 +1,13 @@
+[peapi]
+api_key=
+api_url=
 [postgres]
 host=
 database=
 user=
 password=
 port=
-[peapi]
-api_key=
-api_url=
+
 [blocklist]
 [dehashed]
 [dnstwist]
@@ -15,7 +16,18 @@ api_url=
 [intelx]
 api_key=
 
+[peapi]
+api_key=
+api_url=
+
 [postgresql]
+host=
+database=
+user=
+password=
+port=
+
+[postgres]
 host=
 database=
 user=

--- a/src/pe_reports/data/database.ini
+++ b/src/pe_reports/data/database.ini
@@ -4,7 +4,9 @@ database=
 user=
 password=
 port=
-
+[peapi]
+api_key=
+api_url=
 [blocklist]
 [dehashed]
 [dnstwist]

--- a/src/pe_reports/data/database.ini
+++ b/src/pe_reports/data/database.ini
@@ -10,14 +10,14 @@ api_key=
 api_key=
 api_url=
 
-[postgresql]
+[postgres]
 host=
 database=
 user=
 password=
 port=
 
-[postgres]
+[postgresql]
 host=
 database=
 user=

--- a/src/pe_reports/data/database.ini
+++ b/src/pe_reports/data/database.ini
@@ -1,13 +1,3 @@
-[peapi]
-api_key=
-api_url=
-[postgres]
-host=
-database=
-user=
-password=
-port=
-
 [blocklist]
 [dehashed]
 [dnstwist]

--- a/src/pe_reports/data/db_query.py
+++ b/src/pe_reports/data/db_query.py
@@ -6,6 +6,8 @@ import re
 import sys
 
 # Third-Party Libraries
+import requests
+import json
 import numpy as np
 import pandas as pd
 import psycopg2
@@ -21,6 +23,8 @@ LOGGER = logging.getLogger(__name__)
 
 CONN_PARAMS_DIC = config()
 
+pe_api_key = CONN_PARAMS_DIC.get("pe_api_key")
+pe_api_url = CONN_PARAMS_DIC.get("pe_api_url")
 
 def sanitize_string(string):
     """Remove special characters from string."""
@@ -30,6 +34,9 @@ def sanitize_string(string):
 def sanitize_uid(string):
     """Remove special characters from uids."""
     return re.sub(r"[^a-zA-Z0-9\-\s]", "", string)
+
+
+
 
 
 def show_psycopg2_exception(err):
@@ -56,21 +63,33 @@ def close(conn):
     conn.close()
     return
 
+def get_orgs():
+    """Query organizations table."""
+    headers = {
+        "Content-Type": "application/json",
+        "access_token": f'{pe_api_key}',
+    }
 
-def get_orgs(conn):
-    """Query organizations table for orgs we report on."""
     try:
-        cur = conn.cursor()
-        sql = """SELECT * FROM organizations WHERE report_on"""
-        cur.execute(sql)
-        pe_orgs = cur.fetchall()
-        cur.close()
-        return pe_orgs
-    except (Exception, psycopg2.DatabaseError) as error:
-        LOGGER.error("There was a problem with your database query %s", error)
-    finally:
-        if conn is not None:
-            close(conn)
+
+        response = requests.post(pe_api_url, headers=headers).json()
+        return response
+
+    except requests.exceptions.HTTPError as errh:
+
+        print(errh)
+    except requests.exceptions.ConnectionError as errc:
+
+        print(errc)
+    except requests.exceptions.Timeout as errt:
+
+        print(errt)
+    except requests.exceptions.RequestException as err:
+
+        print(err)
+    except json.decoder.JSONDecodeError as err:
+        # print('its 5')
+        print(err)
 
 
 def get_orgs_df():

--- a/src/pe_reports/data/db_query.py
+++ b/src/pe_reports/data/db_query.py
@@ -1,18 +1,18 @@
 """Query the PE PostgreSQL database."""
 
 # Standard Python Libraries
+import json
 import logging
 import re
 import sys
 
 # Third-Party Libraries
-import requests
-import json
 import numpy as np
 import pandas as pd
 import psycopg2
 from psycopg2 import OperationalError
 from psycopg2.extensions import AsIs
+import requests
 
 from .config import config
 
@@ -22,8 +22,9 @@ from .config import config
 LOGGER = logging.getLogger(__name__)
 
 CONN_PARAMS_DIC = config()
-PE_API_KEY = config(section='peapi').get('api_key') 
-PE_API_URL = config(section='peapi').get('api_url')
+PE_API_KEY = config(section="peapi").get("api_key")
+PE_API_URL = config(section="peapi").get("api_url")
+
 
 def sanitize_string(string):
     """Remove special characters from string."""
@@ -33,9 +34,6 @@ def sanitize_string(string):
 def sanitize_uid(string):
     """Remove special characters from uids."""
     return re.sub(r"[^a-zA-Z0-9\-\s]", "", string)
-
-
-
 
 
 def show_psycopg2_exception(err):
@@ -62,11 +60,12 @@ def close(conn):
     conn.close()
     return
 
+
 def get_orgs():
     """Query organizations table."""
     headers = {
         "Content-Type": "application/json",
-        "access_token": f'{PE_API_KEY}',
+        "access_token": f"{PE_API_KEY}",
     }
     try:
         response = requests.post(PE_API_URL, headers=headers).json()

--- a/src/pe_reports/data/db_query.py
+++ b/src/pe_reports/data/db_query.py
@@ -22,9 +22,8 @@ from .config import config
 LOGGER = logging.getLogger(__name__)
 
 CONN_PARAMS_DIC = config()
-
-pe_api_key = CONN_PARAMS_DIC.get("pe_api_key")
-pe_api_url = CONN_PARAMS_DIC.get("pe_api_url")
+PE_API_KEY = config(section='peapi').get('api_key') 
+PE_API_URL = config(section='peapi').get('api_url')
 
 def sanitize_string(string):
     """Remove special characters from string."""
@@ -67,28 +66,20 @@ def get_orgs():
     """Query organizations table."""
     headers = {
         "Content-Type": "application/json",
-        "access_token": f'{pe_api_key}',
+        "access_token": f'{PE_API_KEY}',
     }
-
     try:
-
-        response = requests.post(pe_api_url, headers=headers).json()
+        response = requests.post(PE_API_URL, headers=headers).json()
         return response
-
     except requests.exceptions.HTTPError as errh:
-
         print(errh)
     except requests.exceptions.ConnectionError as errc:
-
         print(errc)
     except requests.exceptions.Timeout as errt:
-
         print(errt)
     except requests.exceptions.RequestException as err:
-
         print(err)
     except json.decoder.JSONDecodeError as err:
-        # print('its 5')
         print(err)
 
 

--- a/src/pe_source/data/pe_db/db_query_source.py
+++ b/src/pe_source/data/pe_db/db_query_source.py
@@ -462,7 +462,7 @@ def insert_intelx_breaches(df):
     cursor.close()
 
 
-def get_intelx_breaches(source_uid,redo_interval=3):
+def get_intelx_breaches(source_uid, redo_interval=3):
     """
     Query API for all IntelX credential breaches.
 

--- a/src/pe_source/data/pe_db/db_query_source.py
+++ b/src/pe_source/data/pe_db/db_query_source.py
@@ -62,7 +62,7 @@ def get_orgs():
         "access_token": f'{PE_API_KEY}',
     }
     try:
-        response = requests.post(PE_API_URL, headers=headers).json()
+        response = requests.post(PE_API_URL +  "get_orgs/", headers=headers).json()
         return response
     except requests.exceptions.HTTPError as errh:
         print(errh)

--- a/src/pe_source/data/pe_db/db_query_source.py
+++ b/src/pe_source/data/pe_db/db_query_source.py
@@ -1,11 +1,9 @@
 """Query the PE PostgreSQL database."""
 
 # Standard Python Libraries
-from datetime import datetime
-import re
-import requests
-import sys
 import json
+import re
+import sys
 import time
 
 # Third-Party Libraries
@@ -13,6 +11,7 @@ import pandas as pd
 import psycopg2
 from psycopg2 import OperationalError
 import psycopg2.extras as extras
+import requests
 
 # cisagov Libraries
 from pe_reports import app
@@ -64,7 +63,7 @@ def get_orgs():
         "access_token": f"{PE_API_KEY}",
     }
     try:
-        response = requests.post(PE_API_URL +  "get_orgs/", headers=headers).json()
+        response = requests.post(PE_API_URL + "get_orgs/", headers=headers).json()
         return response
     except requests.exceptions.HTTPError as errh:
         print(errh)
@@ -93,7 +92,7 @@ def get_ips(org_uid):
 
 
 def get_data_source_uid(source):
-    """Query organizations table."""
+    """Query data_source table and update the last viewed time."""
     urlOrgs = PE_API_URL
     headers = {
         "Content-Type": "application/json",
@@ -105,7 +104,7 @@ def get_data_source_uid(source):
         ).json()
         # Change last viewed
         uid = response[0]["data_source_uid"]
-        r = requests.put(urlOrgs + "update_last_viewed/" + uid, headers=headers)
+        requests.put(urlOrgs + "update_last_viewed/" + uid, headers=headers)
         LOGGER.info("Updated last viewed for %s", source)
         return response
     except requests.exceptions.HTTPError as errh:

--- a/src/pe_source/data/pe_db/db_query_source.py
+++ b/src/pe_source/data/pe_db/db_query_source.py
@@ -468,6 +468,7 @@ def get_intelx_breaches(source_uid, redo_interval=3):
 
     Args:
         source_uid: The data source uid to filter credential breaches by
+        redo_interval: The amount of time to pause before redoing api call
 
     Return:
         Credential breach data that have the specified data_source_uid as a dataframe

--- a/src/pe_source/data/pe_db/db_query_source.py
+++ b/src/pe_source/data/pe_db/db_query_source.py
@@ -462,7 +462,7 @@ def insert_intelx_breaches(df):
     cursor.close()
 
 
-def get_intelx_breaches(source_uid):
+def get_intelx_breaches(source_uid,redo_interval=3):
     """
     Query API for all IntelX credential breaches.
 
@@ -499,7 +499,7 @@ def get_intelx_breaches(source_uid):
             LOGGER.info(
                 "\tPinged cred_breach_intelx status endpoint, status:", task_status
             )
-            time.sleep(3)
+            time.sleep(redo_interval)
     except requests.exceptions.HTTPError as errh:
         LOGGER.error(errh)
     except requests.exceptions.ConnectionError as errc:

--- a/src/pe_source/data/pe_db/db_query_source.py
+++ b/src/pe_source/data/pe_db/db_query_source.py
@@ -6,6 +6,7 @@ import re
 import requests
 import sys
 import json
+import time
 
 # Third-Party Libraries
 import pandas as pd
@@ -22,8 +23,9 @@ from pe_reports.data.db_query import sanitize_uid
 LOGGER = app.config["LOGGER"]
 
 CONN_PARAMS_DIC = config()
-PE_API_KEY = config(section='peapi').get('api_key') 
-PE_API_URL = config(section='peapi').get('api_url')
+PE_API_KEY = config(section="peapi").get("api_key")
+PE_API_URL = config(section="peapi").get("api_url")
+
 
 def show_psycopg2_exception(err):
     """Handle errors for PostgreSQL issues."""
@@ -59,7 +61,7 @@ def get_orgs():
     """Query organizations table."""
     headers = {
         "Content-Type": "application/json",
-        "access_token": f'{PE_API_KEY}',
+        "access_token": f"{PE_API_KEY}",
     }
     try:
         response = requests.post(PE_API_URL, headers=headers).json()
@@ -95,14 +97,16 @@ def get_data_source_uid(source):
     urlOrgs = PE_API_URL
     headers = {
         "Content-Type": "application/json",
-        "access_token": f'{PE_API_KEY}',
+        "access_token": f"{PE_API_KEY}",
     }
     try:
-        response = requests.post(urlOrgs + "data_source/" + source, headers=headers).json()
-        #Change last viewed
+        response = requests.post(
+            urlOrgs + "data_source/" + source, headers=headers
+        ).json()
+        # Change last viewed
         uid = response[0]["data_source_uid"]
         r = requests.put(urlOrgs + "update_last_viewed/" + uid, headers=headers)
-        LOGGER.info('Updated last viewed for %s', source)
+        LOGGER.info("Updated last viewed for %s", source)
         return response
     except requests.exceptions.HTTPError as errh:
         print(errh)
@@ -460,23 +464,62 @@ def insert_intelx_breaches(df):
 
 
 def get_intelx_breaches(source_uid):
-    """Get IntelX credential breaches."""
-    conn = connect()
+    """
+    Query API for all IntelX credential breaches.
+
+    Args:
+        source_uid: The data source uid to filter credential breaches by
+
+    Return:
+        Credential breach data that have the specified data_source_uid as a dataframe
+    """
+    # Endpoint info
+    create_task_url = PE_API_URL + "cred_breach_intelx"
+    check_task_url = PE_API_URL + "cred_breach_intelx/task/"
+    headers = {
+        "Content-Type": "application/json",
+        "access_token": f"{PE_API_KEY}",
+    }
+    data = json.dumps({"source_uid": source_uid})
     try:
-        cur = conn.cursor()
-        sql = """SELECT breach_name, credential_breaches_uid FROM credential_breaches where data_source_uid = %s"""
-        cur.execute(sql, [source_uid])
-        all_breaches = cur.fetchall()
-        for breach in all_breaches:
-            breach[0] = sanitize_text([0])
-            breach[1] = sanitize_uid(breach[1])
-        cur.close()
-        return all_breaches
-    except (Exception, psycopg2.DatabaseError) as error:
-        LOGGER.error("There was a problem with your database query %s", error)
-    finally:
-        if conn is not None:
-            close(conn)
+        # Create task for query
+        create_task_result = requests.post(
+            create_task_url, headers=headers, data=data
+        ).json()
+        task_id = create_task_result.get("task_id")
+        LOGGER.info(
+            "Created task for cred_breach_intelx endpoint query, task_id: ", task_id
+        )
+        # Once task has been started, keep pinging task status until finished
+        check_task_url += task_id
+        task_status = "Pending"
+        while task_status != "Completed" and task_status != "Failed":
+            # Ping task status endpoint and get status
+            check_task_resp = requests.get(check_task_url, headers=headers).json()
+            task_status = check_task_resp.get("status")
+            LOGGER.info(
+                "\tPinged cred_breach_intelx status endpoint, status:", task_status
+            )
+            time.sleep(3)
+    except requests.exceptions.HTTPError as errh:
+        LOGGER.error(errh)
+    except requests.exceptions.ConnectionError as errc:
+        LOGGER.error(errc)
+    except requests.exceptions.Timeout as errt:
+        LOGGER.error(errt)
+    except requests.exceptions.RequestException as err:
+        LOGGER.error(err)
+    except json.decoder.JSONDecodeError as err:
+        LOGGER.error(err)
+    # Once task finishes, return result
+    if task_status == "Completed":
+        # Convert result to list of tuples to match original function
+        result = [tuple(row.values()) for row in check_task_resp.get("result")]
+        return result
+    else:
+        raise Exception(
+            "cred_breach_intelx query task failed, details: ", check_task_resp
+        )
 
 
 def insert_intelx_credentials(df):


### PR DESCRIPTION
Fixes #639 
## 🗣 Description ##
For preventing sql injection errors the team is focusing on creating more API endpoints to interact with instead of using direct API calls. To get this going we need to modify the get_orgs function in db_query to get the data from the api endpoint in crossfeed rather than directly use TSQL.

## Implementation notes ##
 
- Replace get_orgs()
- Assure the same data is received with using the api rather than TSQL
- Get URL and API_KEY in database.ini file

## 🧪 Testing ##

API endpoint is successfully called using the requests library

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.